### PR TITLE
Fix discord invite urls to a single non-expiring, unlimited use link

### DIFF
--- a/community/join.md
+++ b/community/join.md
@@ -19,7 +19,7 @@ This is a MUST do if you don't want to get left out!
 
 ### Follow these steps to join our Discord server:
 
-1. Click the [invite link](https://discord.gg/gn4DKF83bP) to enter the Discord server.
+1. Click the [invite link](https://discord.gg/mneaSskFT3) to enter the Discord server.
 2. Introduce yourself on the `#introductions` channel and friend request one of the moderators so they can chat with you (you can write `@moderators` in your message to get their attention). They will need to add a role for you as a "member" so you can stay on the server before you log out, otherwise you will have to be invited and join again.
 3. Install Discord on your [computer](https://discord.com/download), [Android](https://play.google.com/store/apps/details?id=com.discord&hl=en_US&gl=US), or [iOS](https://apps.apple.com/us/app/discord-chat-talk-hangout/id985746746) device to always stay up-to-date.
 

--- a/community/teams.md
+++ b/community/teams.md
@@ -12,7 +12,7 @@ If you're interested in helping out, check out what our teams are working on her
 Feel free to have informational meetings with the respective team leads to learn more about how you can help. There's no commitment required and we welcome you to take on as much work as you have the capacity for.
 
 ## Outreach
-Our outreach team is responsible for finding new site host partners, finding users, and maintaining communications with our current partners. Message the [#outreach](https://discord.gg/sZkK5RpeCE) channel in Discord and contact Esther Jang to learn more about how you can get involved.
+Our outreach team is responsible for finding new site host partners, finding users, and maintaining communications with our current partners. Message the [#outreach](https://discord.gg/mneaSskFT3) channel in Discord and contact Esther Jang to learn more about how you can get involved.
 
 This is the perfect team for you if any of the following apply to you:
 - Experience with community organizing
@@ -27,7 +27,7 @@ This is the perfect team for you if any of the following apply to you:
 - Non-English speaking
 
 ## Social Media
-Our social media team is in charge of our various accounts on [Instagram](https://www.instagram.com/seattlecommnet/), [Facebook](https://facebook.com/seattlecommnet), and [Twitter](https://twitter.com/seattlecommnet). They also develop branding and marketing materials for our various projects. Message the [#social-media](https://discord.gg/sZkK5RpeCE) channel in Discord and contact Firn Tieanklin to learn more about how you can get involved.
+Our social media team is in charge of our various accounts on [Instagram](https://www.instagram.com/seattlecommnet/), [Facebook](https://facebook.com/seattlecommnet), and [Twitter](https://twitter.com/seattlecommnet). They also develop branding and marketing materials for our various projects. Message the [#social-media](https://discord.gg/mneaSskFT3) channel in Discord and contact Firn Tieanklin to learn more about how you can get involved.
 
 You should join this team if you have experience in or are interested in practicing any of the following skills/technologies:
 - Canva
@@ -36,7 +36,7 @@ You should join this team if you have experience in or are interested in practic
 - Photography/Videography
 
 ## Web Development
-Our web development team is working on redesigning and developing our new website. Message the [#website](https://discord.gg/sZkK5RpeCE) channel in Discord to learn more about how you can get involved.
+Our web development team is working on redesigning and developing our new website. Message the [#website](https://discord.gg/mneaSskFT3) channel in Discord to learn more about how you can get involved.
 
 You should join this team if you have experience in or are interested in learning any of the following skills/technologies:
 - HTML/CSS
@@ -49,7 +49,7 @@ You should join this team if you have experience in or are interested in learnin
 ## Mobile App Development
 Our mobile app development team is currently developing an Android app to record cell network performance metrics during our field tests.
 
-Message the [#measurement](https://discord.gg/sZkK5RpeCE) channel in Discord and contact Zhennan Zhou to learn more about how you can get involved.
+Message the [#measurement](https://discord.gg/mneaSskFT3) channel in Discord and contact Zhennan Zhou to learn more about how you can get involved.
 
 You should join this team if you have experience in or are interested in learning any of the following skills/technologies:
 - Android app development
@@ -59,7 +59,7 @@ You should join this team if you have experience in or are interested in learnin
 - Open source development, Git, and GitHub
 
 ## Education
-Our education team plays a core role in our community networks as they enable our networks to be community-owned and operated. The education team is responsible for developing educational materials, running workshops, and teaching our Digital Steward cohorts. Message the [#digital-stewards](https://discord.gg/sZkK5RpeCE) channel in Discord and contact Esther Jang to learn more about how you can get involved.
+Our education team plays a core role in our community networks as they enable our networks to be community-owned and operated. The education team is responsible for developing educational materials, running workshops, and teaching our Digital Steward cohorts. Message the [#digital-stewards](https://discord.gg/mneaSskFT3) channel in Discord and contact Esther Jang to learn more about how you can get involved.
 
 You should join this team if you have experience in or are interested in learning any of the following skills/technologies:
 - Teaching
@@ -69,7 +69,7 @@ You should join this team if you have experience in or are interested in learnin
 - Community organizing
 
 ## Fundraising
-Our fundraising team is currently setting up a crowdfunding platform to raise money for various expenses that this project requires. Our fundraising team is also working on applying for various community grants and research grants. Message the [#funding](https://discord.gg/sZkK5RpeCE) channel in Discord and contact Esther Jang to learn more about how you can get involved.
+Our fundraising team is currently setting up a crowdfunding platform to raise money for various expenses that this project requires. Our fundraising team is also working on applying for various community grants and research grants. Message the [#funding](https://discord.gg/mneaSskFT3) channel in Discord and contact Esther Jang to learn more about how you can get involved.
 
 ## Accounting & Legal
 Local Connectivity Lab, the nonprofit organizing that is incubating this project, often runs into accounting and legal challenges. If you are willing to provide pro bono services to benefit the community network, please contact Esther Jang at lcl@seattlecommunitynetwork.org.

--- a/community/tech-help.md
+++ b/community/tech-help.md
@@ -11,11 +11,11 @@ You can use any of these methods to request Internet service from us, request ge
 
 ## Join our Discord!
 
-The FASTEST way to get support will be to join the `#support` channel on our [Discord](https://discord.gg/sZkK5RpeCE), a messaging platform that we use to organize.
+The FASTEST way to get support will be to join the `#support` channel on our [Discord](https://discord.gg/mneaSskFT3), a messaging platform that we use to organize.
 
 ### Follow these steps to join Discord:
 
-1. Join our [Discord server](https://discord.gg/sZkK5RpeCE) via the invite link. You will need to [log in](https://discord.com/login) or create an account to join, and a moderator will need to assign you a role before you are allowed to join permanently.
+1. Join our [Discord server](https://discord.gg/mneaSskFT3) via the invite link. You will need to [log in](https://discord.com/login) or create an account to join, and a moderator will need to assign you a role before you are allowed to join permanently.
 2. Install Discord for your [computer](https://discord.com/download), [Android](https://play.google.com/store/apps/details?id=com.discord&hl=en_US&gl=US), or [iOS](https://apps.apple.com/us/app/discord-chat-talk-hangout/id985746746) device to stay up-to-date on conversations.
 3. When posting to the #support channel, describe your question or problem in as much detail as you can. Someone from the community will most likely respond within a few hours.
 4. If you would like to get to know the community, introduce yourself in the `#introductions` channel! How did you hear about SCN and why are you interested?
@@ -44,7 +44,7 @@ However, you may also drop in during our scheduled calendar hours without an app
 We are actively recruiting more volunteers to help us run the help desk virtually, whenever and wherever that you are available. 
 Join our team by simply signing up on this [interest form](https://forms.gle/iqBYKmjkTYa4gFK98), we need you! 
 
-Please let us know if you have additional questions or concerns in the `#support` channel on our [Discord](https://discord.gg/FN3DDjtAHg). 
+Please let us know if you have additional questions or concerns in the `#support` channel on our [Discord](https://discord.gg/mneaSskFT3). 
 
 ## Documentation
 


### PR DESCRIPTION
Some of the discord invite urls were expired, and when I looked at the repo, I saw that 3 separate urls were being used.

I created a new non-expiring, unlimited use invite link, and changed every occurrence of a discord invite url to the new one.